### PR TITLE
Bugfix/loop capture

### DIFF
--- a/crawlclima/wunderground/wu.py
+++ b/crawlclima/wunderground/wu.py
@@ -102,13 +102,11 @@ def capture(station, date):
     url = wu_url(station, date)
     status = 0
     wait = 1
-    while status != 200:
+    while status != 200 and wait <= 16:
         resp = requests.get(url)
         status = resp.status_code
         time.sleep(wait)
         wait *= 2
-        if wait > 30:
-            break
     print(resp.status_code)
     page = resp.text
     dataframe = parse_page(page)

--- a/crawlclima/wunderground/wu.py
+++ b/crawlclima/wunderground/wu.py
@@ -93,13 +93,9 @@ def capture_date_range(station, date):
     :return:
     """
     today = datetime.datetime.today()
-    data = []
-    while date <= today:
-        if check_day(date, station):
-            data.append(capture(station, date))
-            date = date + datetime.timedelta(1)
-        time.sleep(1)
-    return data
+    check_day_station = lambda d: check_day(d, station)
+    dates = filter(check_day_station, date_generator(today, date))
+    return map(lambda d: capture(station, d), dates)
 
 
 def capture(station, date):


### PR DESCRIPTION
The bug relies on not changing the value of `date` when the pair "day/station" has no weather data. Moreover, we were waiting twice between request, inside `capture_date_range` and inside `capture`.

Use `date_generator` solves it all.